### PR TITLE
Add CORS support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,19 @@
+# An example .env file
+# All secure values like usernames, passwords, secrets, client IDs
+# should be replaced with your own values.
+# Never commit the .env file (with actual sensitive values) to git.
+
+NODE_ENV=PRODUCTION
+JWT_SECRET=some_secret_for_signing_jwts
+CORS_ALLOWED_ORIGINS=http://localhost:3000  # Default: *
+
+POSTGRES_USER=nutrishare
+POSTGRES_PASSWORD=changeme
+POSTGRES_DB=nutrishare
+
+GITHUB_CLIENT_ID=id_of_a_github_oauth2_application
+GITHUB_CLIENT_SECRET=secret_of_a_github_oauth2_application
+
+# Prisma supports the native connection string format for PostgreSQL, MySQL, SQLite, SQL Server, MongoDB and CockroachDB.
+# See the documentation for all the connection string options: https://pris.ly/d/connection-strings
+DATABASE_URL="postgres://nutrishare:changeme@localhost:5432/nutrishare?schema=public"

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -1,7 +1,6 @@
 import Elysia from "elysia";
-import swagger from "./plugins/swagger.plugin";
+import { jwt, swagger } from "./plugins";
 // import auth from "./auth/auth.controller";
-import jwt from "./plugins/jwt.plugin";
 
 const app = new Elysia()
   .use(swagger)

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -1,9 +1,10 @@
 import Elysia from "elysia";
-import { jwt, swagger } from "./plugins";
+import { cors, jwt, swagger } from "./plugins";
 // import auth from "./auth/auth.controller";
 
 const app = new Elysia()
   .use(swagger)
+  .use(cors)
   .use(jwt)
   .get("/foo", () => "bar");
 // .group("/api", (app) => app.use(auth));

--- a/apps/backend/src/auth/auth.controller.ts
+++ b/apps/backend/src/auth/auth.controller.ts
@@ -1,6 +1,6 @@
 import { Elysia } from "elysia";
 import AuthService from "./auth.service";
-import jwt from "../plugins/jwt.plugin";
+import { jwt } from "../plugins";
 import authMiddleware from "./auth.middleware";
 import { userModel } from "../user/user.model";
 import { authModel } from "./auth.model";

--- a/apps/backend/src/auth/auth.middleware.ts
+++ b/apps/backend/src/auth/auth.middleware.ts
@@ -1,5 +1,5 @@
 import Elysia from "elysia";
-import jwt from "../plugins/jwt.plugin";
+import { jwt } from "../plugins";
 import { prisma } from "@nutrishare/db";
 
 class UnauthorizedError extends Error {}

--- a/apps/backend/src/env.ts
+++ b/apps/backend/src/env.ts
@@ -1,9 +1,14 @@
 import { Type, Static } from "@sinclair/typebox";
 import { Value } from "@sinclair/typebox/value";
 
+const SpaceSeparatedArray = Type.Transform(Type.String())
+  .Decode((value) => value.split(" "))
+  .Encode((value) => value.join(" "));
+
 const Env = Type.Object({
   JWT_SECRET: Type.String(),
   NODE_ENV: Type.Optional(Type.Union([Type.Literal("PRODUCTION")])),
+  CORS_ALLOWED_ORIGINS: Type.Optional(SpaceSeparatedArray),
 });
 
 type Env = Static<typeof Env>;

--- a/apps/backend/src/plugins/cors.plugin.ts
+++ b/apps/backend/src/plugins/cors.plugin.ts
@@ -1,0 +1,6 @@
+import cors from "@elysiajs/cors";
+import appEnv from "../env";
+
+export default cors({
+  origin: appEnv.CORS_ALLOWED_ORIGINS ?? true,
+});

--- a/apps/backend/src/plugins/index.ts
+++ b/apps/backend/src/plugins/index.ts
@@ -1,2 +1,3 @@
+export { default as cors } from "./cors.plugin.ts";
 export { default as jwt } from "./jwt.plugin.ts";
 export { default as swagger } from "./swagger.plugin.ts";

--- a/apps/backend/src/plugins/index.ts
+++ b/apps/backend/src/plugins/index.ts
@@ -1,0 +1,2 @@
+export { default as jwt } from "./jwt.plugin.ts";
+export { default as swagger } from "./swagger.plugin.ts";

--- a/packages/libs/src/eden.ts
+++ b/packages/libs/src/eden.ts
@@ -1,4 +1,4 @@
 import { type App } from "@nutrishare/backend";
 import { edenTreaty } from "@elysiajs/eden";
 
-export const treaty = edenTreaty<App>("http://127.0.0.1:8080");
+export const treaty = edenTreaty<App>("http://localhost:8080");

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,7 +17,7 @@ importers:
         version: 1.2.2
       bun-types:
         specifier: latest
-        version: 1.0.2
+        version: 1.0.3
       turbo:
         specifier: ^1.10.14
         version: 1.10.14
@@ -29,7 +29,7 @@ importers:
         version: 0.7.0(elysia@0.7.6)
       '@elysiajs/eden':
         specifier: 0.7.1
-        version: 0.7.1(@sinclair/typebox@0.31.15)(elysia@0.7.6)
+        version: 0.7.1(elysia@0.7.6)
       '@elysiajs/jwt':
         specifier: 0.7.0
         version: 0.7.0(elysia@0.7.6)
@@ -44,14 +44,14 @@ importers:
         version: 0.31.15
       elysia:
         specifier: 0.7.6
-        version: 0.7.6(@sinclair/typebox@0.31.15)(typescript@5.2.2)
+        version: 0.7.6(typescript@5.2.2)
     devDependencies:
       '@nutrishare/tsconfig':
         specifier: workspace:*
         version: link:../../packages/tsconfig
       bun-types:
         specifier: latest
-        version: 1.0.2
+        version: 1.0.3
       typescript:
         specifier: ^5.2.2
         version: 5.2.2
@@ -116,7 +116,7 @@ importers:
         version: link:../tsconfig
       bun-types:
         specifier: latest
-        version: 1.0.2
+        version: 1.0.3
       prisma:
         specifier: ^5.3.1
         version: 5.3.1
@@ -125,7 +125,7 @@ importers:
     dependencies:
       '@elysiajs/eden':
         specifier: ~0.7
-        version: 0.7.1(@sinclair/typebox@0.31.15)(elysia@0.7.6)
+        version: 0.7.1(elysia@0.7.6)
       typescript:
         specifier: ^5.0.0
         version: 5.2.2
@@ -138,7 +138,7 @@ importers:
         version: link:../tsconfig
       bun-types:
         specifier: latest
-        version: 1.0.2
+        version: 1.0.3
 
   packages/tsconfig:
     devDependencies:
@@ -229,10 +229,10 @@ packages:
     peerDependencies:
       elysia: '>= 0.7.0'
     dependencies:
-      elysia: 0.7.6(@sinclair/typebox@0.31.15)(typescript@5.2.2)
+      elysia: 0.7.6(typescript@5.2.2)
     dev: false
 
-  /@elysiajs/eden@0.7.1(@sinclair/typebox@0.31.15)(elysia@0.7.6):
+  /@elysiajs/eden@0.7.1(elysia@0.7.6):
     resolution: {integrity: sha512-t9IxXf+U5bI9T1Pc+NWr6OqcTS0rLvcWrlqX4tJto9FzWB44waFEughCUn/UtQ8mAG1CWWISCkzgV/M7Yi4R9Q==}
     peerDependencies:
       '@sinclair/typebox': '*'
@@ -241,8 +241,7 @@ packages:
       '@sinclair/typebox':
         optional: true
     dependencies:
-      '@sinclair/typebox': 0.31.15
-      elysia: 0.7.6(@sinclair/typebox@0.31.15)(typescript@5.2.2)
+      elysia: 0.7.6(typescript@5.2.2)
     dev: false
 
   /@elysiajs/jwt@0.7.0(elysia@0.7.6):
@@ -250,7 +249,7 @@ packages:
     peerDependencies:
       elysia: '>= 0.7.0'
     dependencies:
-      elysia: 0.7.6(@sinclair/typebox@0.31.15)(typescript@5.2.2)
+      elysia: 0.7.6(typescript@5.2.2)
       jose: 4.14.6
     dev: false
 
@@ -260,7 +259,7 @@ packages:
       elysia: '>= 0.7.0'
     dependencies:
       '@types/lodash.clonedeep': 4.5.7
-      elysia: 0.7.6(@sinclair/typebox@0.31.15)(typescript@5.2.2)
+      elysia: 0.7.6(typescript@5.2.2)
       lodash.clonedeep: 4.5.0
       openapi-types: 12.1.3
     dev: false
@@ -937,8 +936,8 @@ packages:
       fill-range: 7.0.1
     dev: true
 
-  /bun-types@1.0.2:
-    resolution: {integrity: sha512-yqBp2SX9cqr5/GReb56uCfM+YP+Hntx3XPjbqX1VJXqOBu+Yqw8iWRFLKFIsz9uEfykLgflhramQ8a5Jgo+Tlg==}
+  /bun-types@1.0.3:
+    resolution: {integrity: sha512-XlyKVdYCHa7K5PHYGcwOVOrGE/bMnLS51y7zFA3ZAAXyiQ6dTaNXNCWTTufgII/6ruN770uhAXphQmzvU/r2fQ==}
     dev: true
 
   /callsites@3.1.0:
@@ -1022,7 +1021,7 @@ packages:
       esutils: 2.0.3
     dev: true
 
-  /elysia@0.7.6(@sinclair/typebox@0.31.15)(typescript@5.2.2):
+  /elysia@0.7.6(typescript@5.2.2):
     resolution: {integrity: sha512-l6pCa6vTkhJuKGmVD+9XFT6oUR5jiz0YhBAIVQaUI+Lu+BhOVpNJbu4AtCheogXm+eCsQ1D9Ud6YneNn9V5fuA==}
     peerDependencies:
       '@sinclair/typebox': '>= 0.28.10'
@@ -1036,7 +1035,6 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@sinclair/typebox': 0.31.15
       cookie: 0.5.0
       cookie-signature: 1.2.1
       eventemitter3: 5.0.1


### PR DESCRIPTION
Support `Access-Control-*` headers. The `Access-Control-Allow-Origin` header can be configured via the `CORS_ALLOWED_ORIGINS` env variable. If not set, the header defaults to `*`.

Changed the backend's address in the Eden Treaty's config from numeric `127.0.0.1:8080` to the named `localhost:8080`. For some reason, browsers don't resolve the address if numeric/named is mixed up.

The `@elysiajs/cors` plugin also adds several access control headers, but for now we'll keep them as `*`.

Closes #12