### PR TITLE
REFACTOR: Move common Auth logic to a service

### DIFF
--- a/apps/backend/src/auth/auth.controller.ts
+++ b/apps/backend/src/auth/auth.controller.ts
@@ -4,10 +4,7 @@ import { userModel } from "../user/user.model";
 import githubAuth from "./github.auth.controller";
 import localAuth from "./local.auth.controller";
 import googleAuth from "./google.auth.controller";
-
-const schemaDetail = {
-  tags: ["Auth"],
-};
+import { schemaDetail } from "./auth.model";
 
 export default new Elysia({ prefix: "/auth" })
   .use(userModel)

--- a/apps/backend/src/auth/auth.model.ts
+++ b/apps/backend/src/auth/auth.model.ts
@@ -1,5 +1,9 @@
 import { Elysia, t } from "elysia";
 
+export const schemaDetail = {
+  tags: ["Auth"],
+};
+
 const Register = t.Object({
   username: t.String(),
   email: t.String(),

--- a/apps/backend/src/auth/auth.service.ts
+++ b/apps/backend/src/auth/auth.service.ts
@@ -1,0 +1,151 @@
+import Elysia from "elysia";
+import { randomUUID as uuidv4 } from "crypto";
+import { LuciaError } from "lucia";
+import { PrismaClientError } from "@nutrishare/db";
+import { jwt } from "../plugins";
+import { BadRequestError, ConflictError, UnauthorizedError } from "../errors";
+import { auth as localAuth, githubAuth, googleAuth } from "../lucia";
+import { OAuthRequestError } from "@lucia-auth/oauth";
+
+export default new Elysia()
+  .use(jwt)
+  .error({
+    BadRequestError,
+    ConflictError,
+    UnauthorizedError,
+  })
+  .derive(async ({ jwt }) => ({
+    authService: {
+      signToken: async (user: { userId: string; username: string }) => {
+        return jwt.sign({ id: user.userId, sub: user.username });
+      },
+      validateUsername: (username: string) => {
+        if (username.length < 3 || username.length > 20) {
+          throw new BadRequestError(
+            "Username must be between 3 and 20 characters long",
+          );
+        }
+      },
+      validatePassword: (password: string) => {
+        if (password.length < 8 || password.length > 128) {
+          throw new BadRequestError(
+            "Password must be between 8 and 128 characters long",
+          );
+        }
+      },
+      createLocalUser: async (
+        username: string,
+        email: string,
+        password: string,
+      ) => {
+        const userId = uuidv4();
+        try {
+          await localAuth.createUser({
+            userId,
+            key: {
+              providerId: "local",
+              providerUserId: username.toLowerCase(),
+              password,
+            },
+            attributes: {
+              username,
+              email,
+            },
+          });
+          // NOTE: We create an additional key so the user can use their email to log in
+          localAuth.createKey({
+            userId: userId,
+            providerId: "local",
+            providerUserId: email.toLowerCase(),
+            password,
+          });
+          return await localAuth.getUser(userId);
+        } catch (e) {
+          if (e instanceof PrismaClientError) {
+            // Unique constraint violation
+            if (e.code === "P2002") {
+              throw new ConflictError("Username or email already exists");
+            }
+          }
+          throw e;
+        }
+      },
+      authenticateLocalUser: async (login: string, password: string) => {
+        try {
+          const key = await localAuth.useKey(
+            "local",
+            login.toLowerCase(),
+            password,
+          );
+          return await localAuth.getUser(key.userId);
+        } catch (e) {
+          if (e instanceof LuciaError) {
+            if (
+              e.message === "AUTH_INVALID_KEY_ID" ||
+              e.message === "AUTH_INVALID_PASSWORD"
+            ) {
+              throw new UnauthorizedError("Invalid login or password");
+            }
+          }
+          throw e;
+        }
+      },
+      validateOauthState: (state: string, cookieState: string) => {
+        if (cookieState !== state) {
+          throw new UnauthorizedError("Invalid OAuth state");
+        }
+      },
+      authenticateGithubUser: async (code: string) => {
+        try {
+          const { getExistingUser, githubUser, createUser } =
+            await githubAuth.validateCallback(code);
+
+          const getUser = async () => {
+            const existingUser = await getExistingUser();
+            if (existingUser) return existingUser;
+
+            return createUser({
+              userId: uuidv4(),
+              attributes: {
+                username: githubUser.login,
+                email: githubUser.email,
+              },
+            });
+          };
+
+          return await getUser();
+        } catch (e) {
+          if (e instanceof OAuthRequestError) {
+            throw new UnauthorizedError("Authentication with GitHub failed");
+          }
+          throw e;
+        }
+      },
+      authenticateGoogleUser: async (code: string) => {
+        try {
+          const { getExistingUser, googleUser, createUser } =
+            await googleAuth.validateCallback(code);
+
+          const getUser = async () => {
+            const existingUser = await getExistingUser();
+            if (existingUser) return existingUser;
+
+            return createUser({
+              userId: uuidv4(),
+              attributes: {
+                username: googleUser.name,
+                email: googleUser.email,
+              },
+            });
+          };
+
+          return await getUser();
+        } catch (e) {
+          if (e instanceof OAuthRequestError) {
+            throw new UnauthorizedError("Authentication with Google failed");
+          }
+          throw e;
+        }
+      },
+    },
+  }));

--- a/apps/backend/src/auth/local.auth.controller.ts
+++ b/apps/backend/src/auth/local.auth.controller.ts
@@ -1,81 +1,28 @@
 import { Elysia } from "elysia";
-import { jwt } from "../plugins";
 import { userModel } from "../user/user.model";
 import { authModel } from "./auth.model";
-import { randomUUID as uuidv4 } from "crypto";
-import { UnauthorizedError, BadRequestError, ConflictError } from "../errors";
-import { auth } from "../lucia";
-import { PrismaClientError } from "@nutrishare/db";
-import { LuciaError } from "lucia";
-
-const schemaDetail = {
-  tags: ["Auth"],
-};
+import authService from "./auth.service";
+import { schemaDetail } from "./auth.model";
 
 export default new Elysia({ prefix: "/local" })
-  .use(jwt)
   .use(authModel)
   .use(userModel)
-  .error({
-    BadRequestError,
-    ConflictError,
-    UnauthorizedError,
-  })
+  .use(authService)
   .post(
     "/register",
-    async ({ set, body: { username, email, password } }) => {
-      if (username.length < 3 || username.length > 20) {
-        throw new BadRequestError(
-          "Username must be between 3 and 20 characters long",
-        );
-      }
+    async ({ set, body: { username, email, password }, authService }) => {
+      authService.validateUsername(username);
+      authService.validatePassword(password);
 
-      if (password.length < 8 || password.length > 128) {
-        throw new BadRequestError(
-          "Password must be between 8 and 128 characters long",
-        );
-      }
-
-      const userId = uuidv4();
-      try {
-        await auth.createUser({
-          userId,
-          key: {
-            providerId: "local",
-            providerUserId: username.toLowerCase(),
-            password,
-          },
-          attributes: {
-            username,
-            email,
-          },
-        });
-        // NOTE: We create an additional key so the user can use their email to log in
-        auth.createKey({
-          userId: userId,
-          providerId: "local",
-          providerUserId: email.toLowerCase(),
-          password,
-        });
-        const createdUser = await auth.getUser(userId);
-
-        set.status = "Created";
-        return {
-          id: createdUser.userId,
-          createdAt: createdUser.createdAt,
-          updatedAt: createdUser.updatedAt,
-          username,
-          email,
-        };
-      } catch (e) {
-        if (e instanceof PrismaClientError) {
-          // Unique constraint violation
-          if (e.code === "P2002") {
-            throw new ConflictError("Username or email already exists");
-          }
-        }
-        throw e;
-      }
+      const user = await authService.createLocalUser(username, email, password);
+      set.status = "Created";
+      return {
+        id: user.userId,
+        createdAt: user.createdAt,
+        updatedAt: user.updatedAt,
+        username,
+        email,
+      };
     },
     {
       body: "auth.register",
@@ -85,28 +32,11 @@ export default new Elysia({ prefix: "/local" })
   )
   .post(
     "/login",
-    async ({ set, body: { login, password }, jwt }) => {
-      try {
-        const key = await auth.useKey("local", login.toLowerCase(), password);
-        const user = await auth.getUser(key.userId);
-        const accessToken = await jwt.sign({
-          id: user.userId,
-          sub: user.username,
-        });
-
-        set.status = "Created";
-        return { accessToken };
-      } catch (e) {
-        if (e instanceof LuciaError) {
-          if (
-            e.message === "AUTH_INVALID_KEY_ID" ||
-            e.message === "AUTH_INVALID_PASSWORD"
-          ) {
-            throw new UnauthorizedError("Invalid login or password");
-          }
-        }
-        throw e;
-      }
+    async ({ set, body: { login, password }, authService }) => {
+      const user = await authService.authenticateLocalUser(login, password);
+      const accessToken = await authService.signToken(user);
+      set.status = "Created";
+      return { accessToken };
     },
     {
       body: "auth.login",


### PR DESCRIPTION
The service is constructed as an Elysia plugin, so it can facilitate dependency injection and register needed errors.
It's available under `authService` on the Context object.

Closes #24