### PR TITLE
Access token expiration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,11 +4,15 @@
 # Never commit the .env file (with actual sensitive values) to git.
 
 NODE_ENV=PRODUCTION
-JWT_SECRET=some_secret_for_signing_jwts
 CORS_ALLOWED_ORIGINS=http://localhost:3000  # Default: *
 
 
 # Auth
+
+# JWT
+JWT_SECRET=some_secret_for_signing_jwts
+JWT_ACCESS_EXPIRATION=1d
+JWT_REFRESH_EXPIRATION=7d
 
 # The URL to redirect to after a successful authentication
 FRONTEND_AUTH_SUCCESS_CALLBACK_URL=http://localhost:3000/auth/callback

--- a/apps/backend/src/auth/auth.controller.ts
+++ b/apps/backend/src/auth/auth.controller.ts
@@ -5,7 +5,6 @@ import githubAuth from "./github.auth.controller";
 import localAuth from "./local.auth.controller";
 import googleAuth from "./google.auth.controller";
 import { schemaDetail } from "./auth.model";
-import { TokenType } from "../plugins/jwt.plugin";
 import { UnauthorizedError } from "../errors";
 import { prisma } from "@nutrishare/db";
 import authService from "./auth.service";
@@ -16,24 +15,29 @@ export default new Elysia({ prefix: "/auth" })
   .use(localAuth)
   .use(githubAuth)
   .use(googleAuth)
-  .use(authMiddleware)
   .post(
     "/refresh",
-    async ({ body: { refreshToken }, user, authService }) => {
-      await authService.verifyToken(refreshToken, TokenType.Refresh);
+    async ({ body: { refreshToken: providedRefreshToken }, authService }) => {
+      const refreshToken = await authService.verifyRefreshToken(
+        providedRefreshToken,
+      );
+      const userId = refreshToken.id;
 
       const expiredToken = await prisma.refreshToken.findFirst({
-        where: { refreshToken, expired: true },
+        where: { refreshToken: providedRefreshToken, expired: true },
       });
       // If the used refresh token is expired, invalidate all valid refresh tokens for this user
       if (expiredToken) {
         await prisma.refreshToken.updateMany({
-          where: { userId: user.id, expired: false },
+          where: { userId, expired: false },
           data: { expired: true },
         });
         throw new UnauthorizedError();
       }
 
+      const user = await prisma.user.findFirstOrThrow({
+        where: { id: userId },
+      });
       return authService.signTokenPair({
         userId: user.id,
         username: user.username,
@@ -45,6 +49,7 @@ export default new Elysia({ prefix: "/auth" })
       detail: schemaDetail,
     },
   )
+  .use(authMiddleware)
   .get("/me", ({ user }) => user, {
     response: "user.user",
     detail: schemaDetail,

--- a/apps/backend/src/auth/auth.controller.ts
+++ b/apps/backend/src/auth/auth.controller.ts
@@ -5,13 +5,46 @@ import githubAuth from "./github.auth.controller";
 import localAuth from "./local.auth.controller";
 import googleAuth from "./google.auth.controller";
 import { schemaDetail } from "./auth.model";
+import { TokenType } from "../plugins/jwt.plugin";
+import { UnauthorizedError } from "../errors";
+import { prisma } from "@nutrishare/db";
+import authService from "./auth.service";
 
 export default new Elysia({ prefix: "/auth" })
   .use(userModel)
+  .use(authService)
   .use(localAuth)
   .use(githubAuth)
   .use(googleAuth)
   .use(authMiddleware)
+  .post(
+    "/refresh",
+    async ({ body: { refreshToken }, user, authService }) => {
+      await authService.verifyToken(refreshToken, TokenType.Refresh);
+
+      const expiredToken = await prisma.refreshToken.findFirst({
+        where: { refreshToken, expired: true },
+      });
+      // If the used refresh token is expired, invalidate all valid refresh tokens for this user
+      if (expiredToken) {
+        await prisma.refreshToken.updateMany({
+          where: { userId: user.id, expired: false },
+          data: { expired: true },
+        });
+        throw new UnauthorizedError();
+      }
+
+      return authService.signTokenPair({
+        userId: user.id,
+        username: user.username,
+      });
+    },
+    {
+      body: "auth.refresh",
+      response: { 201: "auth.token" },
+      detail: schemaDetail,
+    },
+  )
   .get("/me", ({ user }) => user, {
     response: "user.user",
     detail: schemaDetail,

--- a/apps/backend/src/auth/auth.controller.ts
+++ b/apps/backend/src/auth/auth.controller.ts
@@ -29,7 +29,7 @@ export default new Elysia({ prefix: "/auth" })
       // If the used refresh token is expired, invalidate all valid refresh tokens for this user
       if (expiredToken) {
         await prisma.refreshToken.updateMany({
-          where: { userId, expired: false },
+          where: { user: { id: userId }, expired: false },
           data: { expired: true },
         });
         throw new UnauthorizedError();

--- a/apps/backend/src/auth/auth.controller.ts
+++ b/apps/backend/src/auth/auth.controller.ts
@@ -8,6 +8,7 @@ import { schemaDetail } from "./auth.model";
 import { UnauthorizedError } from "../errors";
 import { prisma } from "@nutrishare/db";
 import authService from "./auth.service";
+import { invalidateTokenFamily } from "./util";
 
 export default new Elysia({ prefix: "/auth" })
   .use(userModel)
@@ -28,10 +29,7 @@ export default new Elysia({ prefix: "/auth" })
       });
       // If the used refresh token is expired, invalidate all valid refresh tokens for this user
       if (expiredToken) {
-        await prisma.refreshToken.updateMany({
-          where: { user: { id: userId }, expired: false },
-          data: { expired: true },
-        });
+        await invalidateTokenFamily(userId);
         throw new UnauthorizedError();
       }
 

--- a/apps/backend/src/auth/auth.middleware.ts
+++ b/apps/backend/src/auth/auth.middleware.ts
@@ -1,7 +1,6 @@
 import Elysia from "elysia";
 import { prisma } from "@nutrishare/db";
 import { UnauthorizedError } from "../errors";
-import { TokenType } from "../plugins/jwt.plugin";
 import authService from "./auth.service";
 
 export default new Elysia()
@@ -14,10 +13,7 @@ export default new Elysia()
     const accessToken = headers["authorization"]?.split(" ")[1];
     if (!accessToken) throw new UnauthorizedError();
 
-    const jwtPayload = await authService.verifyToken(
-      accessToken,
-      TokenType.Access,
-    );
+    const jwtPayload = await authService.verifyAccessToken(accessToken);
 
     const { id } = jwtPayload;
     const user = await prisma.user.findFirst({ where: { id } });

--- a/apps/backend/src/auth/auth.model.ts
+++ b/apps/backend/src/auth/auth.model.ts
@@ -17,6 +17,7 @@ const Login = t.Object({
 
 const Token = t.Object({
   accessToken: t.String(),
+  refreshToken: t.String(),
 });
 
 export const authModel = new Elysia().model({

--- a/apps/backend/src/auth/auth.model.ts
+++ b/apps/backend/src/auth/auth.model.ts
@@ -15,6 +15,10 @@ const Login = t.Object({
   password: t.String(),
 });
 
+const Refresh = t.Object({
+  refreshToken: t.String(),
+});
+
 const Token = t.Object({
   accessToken: t.String(),
   refreshToken: t.String(),
@@ -23,5 +27,6 @@ const Token = t.Object({
 export const authModel = new Elysia().model({
   "auth.register": Register,
   "auth.login": Login,
+  "auth.refresh": Refresh,
   "auth.token": Token,
 });

--- a/apps/backend/src/auth/auth.service.ts
+++ b/apps/backend/src/auth/auth.service.ts
@@ -31,12 +31,12 @@ export default new Elysia()
         });
         // Invalidate all valid refresh tokens for this user
         await prisma.refreshToken.updateMany({
-          where: { userId: user.userId, expired: false },
+          where: { user: { id: user.userId }, expired: false },
           data: { expired: true },
         });
         await prisma.refreshToken.create({
           data: {
-            userId: user.userId,
+            user: { connect: { id: user.userId } },
             refreshToken: refreshToken,
             expired: false,
           },

--- a/apps/backend/src/auth/github.auth.controller.ts
+++ b/apps/backend/src/auth/github.auth.controller.ts
@@ -41,8 +41,10 @@ export default new Elysia({ prefix: "/github" })
       // and fall back to the current behavior if not provided.
       authService.validateOauthState(state, githubAuthState?.toString());
       const user = await authService.authenticateGithubUser(code);
-      const accessToken = await authService.signToken(user);
-      set.redirect = getSuccessCallbackUrl(accessToken);
+      const { accessToken, refreshToken } = await authService.signTokenPair(
+        user,
+      );
+      set.redirect = getSuccessCallbackUrl(accessToken, refreshToken);
     },
     {
       query: t.Object({
@@ -56,7 +58,10 @@ export default new Elysia({ prefix: "/github" })
         ...schemaDetail,
         responses: {
           302: {
-            description: `Redirect to ${getSuccessCallbackUrl("accessToken")}`,
+            description: `Redirect to ${getSuccessCallbackUrl(
+              "accessToken",
+              "refreshToken",
+            )}`,
           },
         },
       },

--- a/apps/backend/src/auth/google.auth.controller.ts
+++ b/apps/backend/src/auth/google.auth.controller.ts
@@ -41,8 +41,10 @@ export default new Elysia({ prefix: "/google" })
       // and fall back to the current behavior if not provided.
       authService.validateOauthState(state, googleAuthState?.toString());
       const user = await authService.authenticateGoogleUser(code);
-      const accessToken = await authService.signToken(user);
-      set.redirect = getSuccessCallbackUrl(accessToken);
+      const { accessToken, refreshToken } = await authService.signTokenPair(
+        user,
+      );
+      set.redirect = getSuccessCallbackUrl(accessToken, refreshToken);
     },
     {
       query: t.Object({
@@ -59,7 +61,10 @@ export default new Elysia({ prefix: "/google" })
         ...schemaDetail,
         responses: {
           302: {
-            description: `Redirect to ${getSuccessCallbackUrl("accessToken")}`,
+            description: `Redirect to ${getSuccessCallbackUrl(
+              "accessToken",
+              "refreshToken",
+            )}`,
           },
         },
       },

--- a/apps/backend/src/auth/local.auth.controller.ts
+++ b/apps/backend/src/auth/local.auth.controller.ts
@@ -34,9 +34,8 @@ export default new Elysia({ prefix: "/local" })
     "/login",
     async ({ set, body: { login, password }, authService }) => {
       const user = await authService.authenticateLocalUser(login, password);
-      const accessToken = await authService.signToken(user);
       set.status = "Created";
-      return { accessToken };
+      return await authService.signTokenPair(user);
     },
     {
       body: "auth.login",

--- a/apps/backend/src/auth/util.ts
+++ b/apps/backend/src/auth/util.ts
@@ -1,3 +1,4 @@
+import { prisma } from "@nutrishare/db";
 import appEnv from ".././env";
 
 export const hashPassword = async (password: string): Promise<string> => {
@@ -9,6 +10,13 @@ export const verifyPassword = async (
   hash: string,
 ): Promise<boolean> => {
   return Bun.password.verify(password, hash);
+};
+
+export const invalidateTokenFamily = async (userId: string) => {
+  return prisma.refreshToken.updateMany({
+    where: { user: { id: userId }, expired: false },
+    data: { expired: true },
+  });
 };
 
 // TODO: Frontend address should be configurable

--- a/apps/backend/src/auth/util.ts
+++ b/apps/backend/src/auth/util.ts
@@ -13,5 +13,8 @@ export const verifyPassword = async (
 
 // TODO: Frontend address should be configurable
 // via a query param to the initial authorization request
-export const getSuccessCallbackUrl = (accessToken: string): string =>
-  `${appEnv.FRONTEND_AUTH_SUCCESS_CALLBACK_URL}?accessToken=${accessToken}`;
+export const getSuccessCallbackUrl = (
+  accessToken: string,
+  refreshToken: string,
+): string =>
+  `${appEnv.FRONTEND_AUTH_SUCCESS_CALLBACK_URL}?accessToken=${accessToken}&refreshToken=${refreshToken}`;

--- a/apps/backend/src/env.ts
+++ b/apps/backend/src/env.ts
@@ -23,6 +23,8 @@ const OptionalEnv = Type.Object({
     { default: "PRODUCTION" },
   ),
   CORS_ALLOWED_ORIGINS: SpaceSeparatedArray("*"),
+  JWT_ACCESS_EXPIRATION: Type.String({ default: "1d" }),
+  JWT_REFRESH_EXPIRATION: Type.String({ default: "7d" }),
 });
 
 const Env = Type.Composite([RequiredEnv, OptionalEnv]);

--- a/apps/backend/src/plugins/jwt.plugin.ts
+++ b/apps/backend/src/plugins/jwt.plugin.ts
@@ -4,6 +4,11 @@ import appEnv from "../env";
 
 const jwtSecret = appEnv.JWT_SECRET;
 
+export enum TokenType {
+  Access = "access",
+  Refresh = "refresh",
+}
+
 export default jwt({
   name: "jwt",
   secret: jwtSecret,
@@ -11,5 +16,6 @@ export default jwt({
   schema: t.Object({
     id: t.String(),
     sub: t.String(),
+    typ: t.Enum(TokenType),
   }),
 });

--- a/apps/backend/src/plugins/jwt.plugin.ts
+++ b/apps/backend/src/plugins/jwt.plugin.ts
@@ -1,21 +1,36 @@
 import jwt from "@elysiajs/jwt";
-import { t } from "elysia";
+import Elysia, { t } from "elysia";
 import appEnv from "../env";
-
-const jwtSecret = appEnv.JWT_SECRET;
 
 export enum TokenType {
   Access = "access",
   Refresh = "refresh",
 }
 
-export default jwt({
-  name: "jwt",
-  secret: jwtSecret,
-  exp: "7d",
-  schema: t.Object({
-    id: t.String(),
-    sub: t.String(),
-    typ: t.Enum(TokenType),
-  }),
-});
+export default new Elysia()
+  .use(
+    jwt({
+      name: "accessJwt",
+      secret: appEnv.JWT_SECRET,
+      exp: appEnv.JWT_ACCESS_EXPIRATION,
+      typ: TokenType.Access,
+      schema: t.Object({
+        id: t.String(),
+        sub: t.String(),
+        typ: t.Enum(TokenType),
+      }),
+    }),
+  )
+  .use(
+    jwt({
+      name: "refreshJwt",
+      secret: appEnv.JWT_SECRET,
+      exp: appEnv.JWT_REFRESH_EXPIRATION,
+      typ: TokenType.Refresh,
+      schema: t.Object({
+        id: t.String(),
+        sub: t.String(),
+        typ: t.Enum(TokenType),
+      }),
+    }),
+  );

--- a/apps/client/src/App.tsx
+++ b/apps/client/src/App.tsx
@@ -13,7 +13,7 @@ type User = {
 };
 
 const App = () => {
-  const { accessToken, setAccessToken } = useAuthContext();
+  const { accessToken, setAccessToken, setRefreshToken } = useAuthContext();
   const [user, setUser] = useState<User>();
 
   useEffect(() => {
@@ -35,8 +35,9 @@ const App = () => {
 
   const onLogout = () => {
     setAccessToken(null);
+    setRefreshToken(null);
     setUser(undefined);
-  }
+  };
 
   return (
     <>
@@ -45,10 +46,11 @@ const App = () => {
       {user && (
         <div>
           <p>
-
-          Logged in as {user.username} ({user.id})
+            Logged in as {user.username} ({user.id})
           </p>
-          <button type="button" onClick={onLogout}>Logout</button>
+          <button type="button" onClick={onLogout}>
+            Logout
+          </button>
         </div>
       )}
       {user === undefined && (

--- a/apps/client/src/context/authContext.tsx
+++ b/apps/client/src/context/authContext.tsx
@@ -11,6 +11,8 @@ import {
 type AuthContextType = {
   accessToken: string | null;
   setAccessToken: (token: string | null) => void;
+  refreshToken: string | null;
+  setRefreshToken: (token: string | null) => void;
 };
 
 const AuthContext = createContext<AuthContextType | null>(null);
@@ -19,11 +21,17 @@ export const AuthContextProvider = ({
   children,
 }: { children: React.ReactNode }) => {
   const [accessToken, _setAccessToken] = useState<string | null>(null);
+  const [refreshToken, _setRefreshToken] = useState<string | null>(null);
 
   useEffect(() => {
     const token = localStorage.getItem("accessToken");
     _setAccessToken(token);
   }, [_setAccessToken]);
+
+  useEffect(() => {
+    const token = localStorage.getItem("refreshToken");
+    _setRefreshToken(token);
+  }, [_setRefreshToken]);
 
   const setAccessToken = useCallback((token: string | null) => {
     if (token === null) {
@@ -35,8 +43,20 @@ export const AuthContextProvider = ({
     _setAccessToken(token);
   }, []);
 
+  const setRefreshToken = useCallback((token: string | null) => {
+    if (token === null) {
+      localStorage.removeItem("refreshToken");
+      return;
+    }
+
+    localStorage.setItem("refreshToken", token);
+    _setRefreshToken(token);
+  }, []);
+
   return (
-    <AuthContext.Provider value={{ accessToken, setAccessToken }}>
+    <AuthContext.Provider
+      value={{ accessToken, setAccessToken, refreshToken, setRefreshToken }}
+    >
       {children}
     </AuthContext.Provider>
   );

--- a/apps/client/src/context/authContext.tsx
+++ b/apps/client/src/context/authContext.tsx
@@ -20,34 +20,34 @@ const AuthContext = createContext<AuthContextType | null>(null);
 export const AuthContextProvider = ({
   children,
 }: { children: React.ReactNode }) => {
-  const [accessToken, _setAccessToken] = useState<string | null>(null);
-  const [refreshToken, _setRefreshToken] = useState<string | null>(null);
+  const [accessToken, setAccessToken] = useState<string | null>(null);
+  const [refreshToken, setRefreshToken] = useState<string | null>(null);
 
   useEffect(() => {
     const token = localStorage.getItem("accessToken");
-    _setAccessToken(token);
-  }, [_setAccessToken]);
+    if (token) setAccessToken(token);
+  }, [setAccessToken]);
 
   useEffect(() => {
     const token = localStorage.getItem("refreshToken");
-    _setRefreshToken(token);
-  }, [_setRefreshToken]);
+    if (token) setRefreshToken(token);
+  }, [setRefreshToken]);
 
-  const setAccessToken = useCallback((token: string | null) => {
-    if (token === null) {
+  useEffect(() => {
+    if (accessToken === null) {
       localStorage.removeItem("accessToken");
       return;
     }
+    localStorage.setItem("accessToken", accessToken);
+  }, [accessToken]);
 
-    localStorage.setItem("accessToken", token);
-    _setAccessToken(token);
-  }, []);
-
-  const setRefreshToken = useCallback((token: string | null) => {
-    if (token === null) {
+  useEffect(() => {
+    if (refreshToken === null) {
       localStorage.removeItem("refreshToken");
       return;
     }
+    localStorage.setItem("refreshToken", refreshToken);
+  }, [refreshToken]);
 
     localStorage.setItem("refreshToken", token);
     _setRefreshToken(token);

--- a/apps/client/src/routes/auth/AuthCallbackPage.tsx
+++ b/apps/client/src/routes/auth/AuthCallbackPage.tsx
@@ -5,19 +5,21 @@ import { useAuthContext } from "../../context/authContext";
 const AuthCallbackPage = () => {
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
-  const { setAccessToken } = useAuthContext();
+  const { setAccessToken, setRefreshToken } = useAuthContext();
 
   useEffect(() => {
     const accessToken = searchParams.get("accessToken");
-    if (accessToken === null) {
+    const refreshToken = searchParams.get("refreshToken");
+    if (accessToken === null || refreshToken === null) {
       // TODO: Better error handling
       console.log("No token found in URL");
       return;
     }
 
     setAccessToken(accessToken);
+    setRefreshToken(refreshToken);
     navigate("/");
-  }, [searchParams, setAccessToken, navigate]);
+  }, [searchParams, setAccessToken, setRefreshToken, navigate]);
 
   return (
     <>

--- a/apps/client/src/routes/auth/LoginPage.tsx
+++ b/apps/client/src/routes/auth/LoginPage.tsx
@@ -9,7 +9,7 @@ type LoginForm = {
 };
 
 const LoginPage = () => {
-  const { setAccessToken } = useAuthContext();
+  const { setAccessToken, setRefreshToken } = useAuthContext();
   const navigate = useNavigate();
 
   const {
@@ -26,6 +26,7 @@ const LoginPage = () => {
     }
 
     setAccessToken(res.data.accessToken);
+    setRefreshToken(res.data.refreshToken);
     navigate("/");
   };
 

--- a/packages/db/prisma/migrations/20231212202505_refresh_token/migration.sql
+++ b/packages/db/prisma/migrations/20231212202505_refresh_token/migration.sql
@@ -1,0 +1,17 @@
+-- CreateTable
+CREATE TABLE "RefreshToken" (
+    "id" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "userId" TEXT NOT NULL,
+    "refreshToken" TEXT NOT NULL,
+    "expired" BOOLEAN NOT NULL DEFAULT false,
+
+    CONSTRAINT "RefreshToken_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "RefreshToken_id_key" ON "RefreshToken"("id");
+
+-- CreateIndex
+CREATE INDEX "RefreshToken_userId_idx" ON "RefreshToken"("userId");

--- a/packages/db/prisma/migrations/20231216212123_refresh_token_user_relation/migration.sql
+++ b/packages/db/prisma/migrations/20231216212123_refresh_token_user_relation/migration.sql
@@ -1,0 +1,2 @@
+-- AddForeignKey
+ALTER TABLE "RefreshToken" ADD CONSTRAINT "RefreshToken_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -25,3 +25,14 @@ model AuthKey {
 
   @@index([user_id])
 }
+
+model RefreshToken {
+  id           String   @id @unique @default(uuid())
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+  userId       String
+  refreshToken String
+  expired      Boolean  @default(false)
+
+  @@index(userId)
+}

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -15,6 +15,7 @@ model User {
   email     String?  @unique
 
   authKey AuthKey[]
+  refreshToken RefreshToken[]
 }
 
 model AuthKey {
@@ -31,6 +32,7 @@ model RefreshToken {
   createdAt    DateTime @default(now())
   updatedAt    DateTime @updatedAt
   userId       String
+  user         User     @relation(fields: [userId], references: [id])
   refreshToken String
   expired      Boolean  @default(false)
 


### PR DESCRIPTION
New stuff:
- All login methods return an (`accessToken`, `refreshToken`) pair
- `/api/auth/refresh` endpoint for creating a new token pair
- Reuse detection - when an expried refreshToken is attempted to be used, invalidate the whole token family (all Users' tokens) to prevent playback attacks
- Configurable access/refresh token lifetimes (via env variables) - access tokens should have very short lifetimes, while refresh tokens can last weeks
- Utility for refreshing the token pair on the frontend - `refreshTokenPair` in the auth slice
- Simplified localStorage persistence logic in the auth context

What would be nice to have, but we can certainly implement it later, is some sort of request interceptor or wrapper. I couldn't find a way to create a valid wrapper for request methods from Eden treaty.

Closes #23 